### PR TITLE
Fix android builds

### DIFF
--- a/android/src/main/java/com/reactnativepayments/ReactNativePaymentsModule.java
+++ b/android/src/main/java/com/reactnativepayments/ReactNativePaymentsModule.java
@@ -5,11 +5,11 @@ import android.view.WindowManager;
 import android.app.Activity;
 import android.content.Intent;
 import android.os.Bundle;
-import android.support.annotation.Nullable;
-import android.support.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.annotation.NonNull;
 import android.app.Fragment;
 import android.app.FragmentManager;
-import android.support.annotation.RequiresPermission;
+import anroidx.annotation.RequiresPermission;
 import android.util.Log;
 
 import com.facebook.react.bridge.Callback;

--- a/android/src/main/java/com/reactnativepayments/ReactNativePaymentsModule.java
+++ b/android/src/main/java/com/reactnativepayments/ReactNativePaymentsModule.java
@@ -9,7 +9,6 @@ import androidx.annotation.Nullable;
 import androidx.annotation.NonNull;
 import android.app.Fragment;
 import android.app.FragmentManager;
-import anroidx.annotation.RequiresPermission;
 import android.util.Log;
 
 import com.facebook.react.bridge.Callback;


### PR DESCRIPTION
Use of the deprecated android support library breaks the build when this package is used in our app. Use the androidx. versions of these classes instead.