### PR TITLE
Client handles payment method change

### DIFF
--- a/js/PaymentRequest/__tests__/PaymentRequestUpdateEvent.test.js
+++ b/js/PaymentRequest/__tests__/PaymentRequestUpdateEvent.test.js
@@ -14,11 +14,8 @@ const PaymentRequestUpdateEvent = require('../PaymentRequestUpdateEvent')
 import {
   createCreatedPaymentRequest,
   createInteractivePaymentRequest,
-  createInteractiveCreditPaymentRequest,
-  createInteractiveDebitPaymentRequest,
   createClosedPaymentRequest,
-  createUpdatingPaymentRequest,
-  APPLE_PAY_DETAILS
+  createUpdatingPaymentRequest
 } from './index.test.js';
 
 // constants
@@ -65,7 +62,7 @@ describe('PaymentRequestUpdateEvent', () => {
   const paymentRequest = new PaymentRequest(METHOD_DATA, DETAILS, OPTIONS);
 
   describe('constructor', () => {
-    it("should throw if `name` isn't `shippingaddresschange` or `shippingoptionchange` or `paymentmethodchange`", () => {
+    it("should throw if `name` isn't `shippingaddresschange` or `shippingoptionchange`", () => {
       expect(() => {
         const paymentRequestUpdateEvent = new PaymentRequestUpdateEvent(
           'foo',
@@ -91,30 +88,6 @@ describe('PaymentRequestUpdateEvent', () => {
       it('should return the PaymentRequest instance', () => {
         const paymentRequestUpdateEvent = new PaymentRequestUpdateEvent(
           'shippingaddresschange',
-          paymentRequest
-        );
-
-        expect(paymentRequestUpdateEvent.target).toBeInstanceOf(PaymentRequest);
-      });
-    });
-  });
-
-  describe('attributes', () => {
-    describe('name', () => {
-      it('should return the event name paymentmethodchange', () => {
-        const paymentRequestUpdateEvent = new PaymentRequestUpdateEvent(
-          'paymentmethodchange',
-          paymentRequest
-        );
-
-        expect(paymentRequestUpdateEvent.name).toBe('paymentmethodchange');
-      });
-    });
-
-    describe('target', () => {
-      it('should return the PaymentRequest instance paymentmethodchange', () => {
-        const paymentRequestUpdateEvent = new PaymentRequestUpdateEvent(
-          'paymentmethodchange',
           paymentRequest
         );
 
@@ -150,82 +123,6 @@ describe('PaymentRequestUpdateEvent', () => {
         ],
         modifiers: 'foo' // Not sure how these are used yet
       };
-
-      const updateCreditDetails = {
-        id: 'credit_card_details',
-        displayItems: [
-          {
-            label: 'Movie Ticket',
-            amount: {currency: 'USD', value: '15.00'}
-          },
-          {
-            label: 'Fee',
-            amount: {currency: 'USD', value: '3.50'}
-          }
-        ],
-        shippingOptions: [{
-          id: 'economy',
-          label: 'Economy Shipping',
-          amount: {currency: 'USD', value: '0.00'},
-          detail: 'Arrives in 3-5 days' // `detail` is specific to React Native Payments
-        }],
-        total: {
-          label: 'Merchant Name',
-          amount: {currency: 'USD', value: '18.50'},
-        }
-      };
-
-      const updateDebitDetails = {
-        id: 'debit_card_details',
-        displayItems: [
-          {
-            label: 'Movie Ticket',
-            amount: {currency: 'USD', value: '15.00'}
-          },
-          {
-            label: 'Fee',
-            amount: {currency: 'USD', value: '2.99'}
-          }
-        ],
-        shippingOptions: [{
-          id: 'economy',
-          label: 'Economy Shipping',
-          amount: {currency: 'USD', value: '0.00'},
-          detail: 'Arrives in 3-5 days' // `detail` is specific to React Native Payments
-        }],
-        total: {
-          label: 'Merchant Name',
-          amount: {currency: 'USD', value: '17.99'},
-        }
-      };
-
-      const DEFAULT_DETAILS = {
-        id: 'default_details',
-        displayItems: [
-          {
-            label: 'Rent',
-            amount: {currency: 'USD', value: '15.00'}
-          },
-          {
-            label: 'Fee',
-            amount: {currency: 'USD', value: '0.00'}
-          }
-        ],
-        shippingOptions: [{
-          id: 'economy',
-          label: 'Economy Shipping',
-          amount: {currency: 'USD', value: '0.00'},
-          detail: 'Arrives in 3-5 days' // `detail` is specific to React Native Payments
-        }],
-        total: {
-          label: 'Merchant Name',
-          amount: {currency: 'USD', value: '10'},
-        }
-      };
-
-      const updatedCreditDetails = Object.assign({}, DEFAULT_DETAILS, updateCreditDetails);
-      const updatedDebitDetails = Object.assign({}, DEFAULT_DETAILS, updateDebitDetails);
-
       const updatedDetails = Object.assign({}, DETAILS, updateDetails);
 
       it('should throw if `target` is not an instance of PaymentRequest', async () => {
@@ -354,38 +251,6 @@ describe('PaymentRequestUpdateEvent', () => {
         expect(interactivePaymentRequest._details).toEqual(updatedDetails);
       });
 
-      it('should successfully update target details for credit paymentmethodchange when passed an Object', async () => {
-        const interactivePaymentRequest = createInteractiveCreditPaymentRequest(
-          METHOD_DATA,
-          APPLE_PAY_DETAILS,
-          OPTIONS
-        );
-        const paymentRequestUpdateEvent = new PaymentRequestUpdateEvent(
-          'paymentmethodchange',
-          interactivePaymentRequest
-        );
-
-        await paymentRequestUpdateEvent.updateWith(updateCreditDetails);
-
-        expect(interactivePaymentRequest._details).toEqual(updatedCreditDetails);
-      });
-
-      it('should successfully update target details for debit paymentmethodchange when passed an Object', async () => {
-        const interactivePaymentRequest = createInteractiveDebitPaymentRequest(
-            METHOD_DATA,
-            APPLE_PAY_DETAILS,
-            OPTIONS
-        );
-        const paymentRequestUpdateEvent = new PaymentRequestUpdateEvent(
-            'paymentmethodchange',
-            interactivePaymentRequest
-        );
-
-        await paymentRequestUpdateEvent.updateWith(updateDebitDetails);
-
-        expect(interactivePaymentRequest._details).toEqual(updatedDebitDetails);
-      });
-
       it('should successfully update target details when passed a Promise that returns an Object', async () => {
         const interactivePaymentRequest = createInteractivePaymentRequest(
           METHOD_DATA,
@@ -402,42 +267,6 @@ describe('PaymentRequestUpdateEvent', () => {
         });
 
         expect(interactivePaymentRequest._details).toEqual(updatedDetails);
-      });
-
-      it('should successfully update target details for credit paymentmethodchange when passed a Promise that returns an Object', async () => {
-        const interactivePaymentRequest = createInteractiveCreditPaymentRequest(
-            METHOD_DATA,
-            APPLE_PAY_DETAILS,
-            OPTIONS
-        );
-        const paymentRequestUpdateEvent = new PaymentRequestUpdateEvent(
-            'paymentmethodchange',
-            interactivePaymentRequest
-        );
-
-        await paymentRequestUpdateEvent.updateWith(() => {
-          return Promise.resolve(updateCreditDetails);
-        });
-
-        expect(interactivePaymentRequest._details).toEqual(updatedCreditDetails);
-      });
-
-      it('should successfully update target details for debit paymentmethodchange when passed a Promise that returns an Object', async () => {
-        const interactivePaymentRequest = createInteractiveDebitPaymentRequest(
-            METHOD_DATA,
-            APPLE_PAY_DETAILS,
-            OPTIONS
-        );
-        const paymentRequestUpdateEvent = new PaymentRequestUpdateEvent(
-            'paymentmethodchange',
-            interactivePaymentRequest
-        );
-
-        await paymentRequestUpdateEvent.updateWith(() => {
-          return Promise.resolve(updateDebitDetails);
-        });
-
-        expect(interactivePaymentRequest._details).toEqual(updatedDebitDetails);
       });
 
       it('should return a rejected promise upon rejection of the details Promise', async () => {
@@ -460,7 +289,7 @@ describe('PaymentRequestUpdateEvent', () => {
         } catch(e) {
           error = e;
         }
-
+        
         expect(error.message).toBe('Error fetching shipping prices.');
       });
     });

--- a/js/PaymentRequest/__tests__/index.test.js
+++ b/js/PaymentRequest/__tests__/index.test.js
@@ -22,22 +22,6 @@ export function createInteractivePaymentRequest(methodData, details, options) {
   return paymentRequest;
 }
 
-export function createInteractiveCreditPaymentRequest(methodData, details, options) {
-  const paymentRequest = new PaymentRequest(methodData, details, options);
-  paymentRequest._state = 'interactive';
-  paymentRequest._paymentMethod = 'PKPaymentMethodTypeCredit';
-
-  return paymentRequest;
-}
-
-export function createInteractiveDebitPaymentRequest(methodData, details, options) {
-  const paymentRequest = new PaymentRequest(methodData, details, options);
-  paymentRequest._state = 'interactive';
-  paymentRequest._paymentMethod = 'PKPaymentMethodTypeDebit';
-
-  return paymentRequest;
-}
-
 export function createClosedPaymentRequest(methodData, details, options) {
   const paymentRequest = new PaymentRequest(methodData, details, options);
   paymentRequest._state = 'closed';
@@ -79,79 +63,6 @@ const DETAILS = {
   displayItems
 };
 
-export const APPLE_PAY_DETAILS =
-    {
-      default: {
-        id: 'default_details',
-        displayItems: [
-          {
-            label: 'Rent',
-            amount: {currency: 'USD', value: '15.00'}
-          },
-          {
-            label: 'Fee',
-            amount: {currency: 'USD', value: '0.00'}
-          }
-        ],
-        shippingOptions: [{
-          id: 'economy',
-          label: 'Economy Shipping',
-          amount: {currency: 'USD', value: '0.00'},
-          detail: 'Arrives in 3-5 days' // `detail` is specific to React Native Payments
-        }],
-        total: {
-          label: 'Merchant Name',
-          amount: {currency: 'USD', value: '10'},
-        }
-      },
-      credit: {
-        id: 'credit_card_details',
-        displayItems: [
-          {
-            label: 'Movie Ticket',
-            amount: {currency: 'USD', value: '15.00'}
-          },
-          {
-            label: 'Fee',
-            amount: {currency: 'USD', value: '3.50'}
-          }
-        ],
-        shippingOptions: [{
-          id: 'economy',
-          label: 'Economy Shipping',
-          amount: {currency: 'USD', value: '0.00'},
-          detail: 'Arrives in 3-5 days' // `detail` is specific to React Native Payments
-        }],
-        total: {
-          label: 'Merchant Name',
-          amount: {currency: 'USD', value: '18.50'},
-        }
-      },
-      debit: {
-        id: 'debit_card_details',
-        displayItems: [
-          {
-            label: 'Movie Ticket',
-            amount: {currency: 'USD', value: '15.00'}
-          },
-          {
-            label: 'Fee',
-            amount: {currency: 'USD', value: '2.99'}
-          }
-        ],
-        shippingOptions: [{
-          id: 'economy',
-          label: 'Economy Shipping',
-          amount: {currency: 'USD', value: '0.00'},
-          detail: 'Arrives in 3-5 days' // `detail` is specific to React Native Payments
-        }],
-        total: {
-          label: 'Merchant Name',
-          amount: {currency: 'USD', value: '17.99'},
-        }
-      }
-    };
-
 describe('PaymentRequest', () => {
   describe('constructor', () => {});
 
@@ -167,14 +78,6 @@ describe('PaymentRequest', () => {
         const request = new PaymentRequest(METHOD_DATA, DETAILS);
 
         expect(request.id).toBeTruthy();
-      });
-    });
-
-    describe('id', () => {
-      it('should have the same id as `details.id`', () => {
-        const request = new PaymentRequest(METHOD_DATA, APPLE_PAY_DETAILS);
-
-        expect(request.id).toBe('default_details');
       });
     });
 

--- a/js/PaymentRequest/index.js
+++ b/js/PaymentRequest/index.js
@@ -276,6 +276,10 @@ export default class PaymentRequest {
   _handlePaymentMethodChange(paymentMethod: PaymentMethod) {
     this._paymentMethod = paymentMethod.paymentMethodType;
 
+    if (IS_IOS && this._paymentMethod) {
+      this._paymentMethod = this._paymentMethod.replace('PKPaymentMethodType','').toLowerCase();
+    }
+
     const event = new PaymentRequestUpdateEvent(PAYMENT_METHOD_CHANGE_EVENT, this);
 
     // Eventually calls `PaymentRequestUpdateEvent._handleDetailsUpdate` when

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@appfolio/react-native-payments",
-  "version": "0.9.0-pre.1",
+  "version": "0.9.0-pre.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@appfolio/react-native-payments",
-  "version": "0.9.0-pre.6",
+  "version": "0.9.0-pre.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@appfolio/react-native-payments",
-  "version": "0.9.0-pre.1",
+  "version": "0.9.0-pre.6",
   "description": "Welcome to the best and most comprehensive library for integrating payments like Apple Pay and Google Pay into your React Native app.",
   "scripts": {
     "run:packager": "cd examples/native && yarn run:packager",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@appfolio/react-native-payments",
-  "version": "0.9.0-pre.6",
+  "version": "0.9.0-pre.7",
   "description": "Welcome to the best and most comprehensive library for integrating payments like Apple Pay and Google Pay into your React Native app.",
   "scripts": {
     "run:packager": "cd examples/native && yarn run:packager",


### PR DESCRIPTION
- Make the client of the library handle payment method changes
- Clean up the test suite
- Remove storing of credit and debit details from the PaymentRequest
