### PR TITLE
Upgrade Braintree to v5

### DIFF
--- a/react-native-payments.podspec
+++ b/react-native-payments.podspec
@@ -16,5 +16,5 @@ Pod::Spec.new do |s|
 
   s.dependency 'React'
   s.dependency 'Stripe', '~> 19'
-  s.dependency 'Braintree', '~> 4'
+  s.dependency 'Braintree', '~> 5'
 end


### PR DESCRIPTION
Upgrade Braintree dependency to remove usage of `SFAuthenticationSession`, which is deprecated and will cause App Store rejection if used.