### PR TITLE
Support pending payment items.

### DIFF
--- a/ios/ReactNativePayments.m
+++ b/ios/ReactNativePayments.m
@@ -332,7 +332,14 @@ RCT_EXPORT_METHOD(handleDetailsUpdate: (NSDictionary *)details
 - (PKPaymentSummaryItem *_Nonnull)convertDisplayItemToPaymentSummaryItem:(NSDictionary *_Nonnull)displayItem;
 {
     NSDecimalNumber *decimalNumberAmount = [NSDecimalNumber decimalNumberWithString:displayItem[@"amount"][@"value"]];
-    PKPaymentSummaryItem *paymentSummaryItem = [PKPaymentSummaryItem summaryItemWithLabel:displayItem[@"label"] amount:decimalNumberAmount];
+    PKPaymentSummaryItemType itemType = PKPaymentSummaryItemTypeFinal;
+    if ([displayItem[@"pending"] respondsToSelector:@selector(boolValue)] && [displayItem[@"pending"] boolValue] == YES) {
+        itemType = PKPaymentSummaryItemTypePending;
+    }
+    PKPaymentSummaryItem *paymentSummaryItem = [PKPaymentSummaryItem
+                                                summaryItemWithLabel:displayItem[@"label"]
+                                                amount:decimalNumberAmount
+                                                type:itemType];
 
     return paymentSummaryItem;
 }


### PR DESCRIPTION
Sometimes, a payment flow takes place where a user agrees to a payment where the amount is pending, such as when setting up automatic monthly payments for a bill balance (which can be variable month to month).

Support payment summary items being of type pending for apple pay.