### PR TITLE
Stop using DeviceEventEmitter.removeSubscription.

### DIFF
--- a/js/PaymentRequest/index.js
+++ b/js/PaymentRequest/index.js
@@ -435,19 +435,13 @@ export default class PaymentRequest {
 
   _removeEventListeners() {
     // Internal Events
-    DeviceEventEmitter.removeSubscription(this._userDismissSubscription);
-    DeviceEventEmitter.removeSubscription(this._userAcceptSubscription);
+    this._userDismissSubscription.remove();
+    this._userAcceptSubscription.remove();
 
     if (IS_IOS) {
-      DeviceEventEmitter.removeSubscription(
-        this._shippingAddressChangeSubscription
-      );
-      DeviceEventEmitter.removeSubscription(
-        this._shippingOptionChangeSubscription
-      );
-      DeviceEventEmitter.removeSubscription(
-        this._paymentMethodChangeSubscription
-      );
+      this._shippingAddressChangeSubscription.remove();
+      this._shippingOptionChangeSubscription.remove();
+      this._paymentMethodChangeSubscription.remove();
     }
   }
 


### PR DESCRIPTION
removeSubscription was removed in react-native 0.70

ps-id: b7d9c819-4942-4ace-b590-b34914409052