### PR TITLE
Add applePayEnabled static method to PaymentRequest. [MITM-866]

### DIFF
--- a/js/NativeBridge/index.js
+++ b/js/NativeBridge/index.js
@@ -9,6 +9,7 @@ const IS_ANDROID = Platform.OS === 'android';
 
 const NativePayments: {
   canMakePayments: boolean,
+  applePayEnabled: () => boolean,
   canMakePaymentsUsingNetworks: boolean,
   openPaymentSetup: void,
   supportedGateways: Array<string>,
@@ -38,6 +39,13 @@ const NativePayments: {
       // On iOS, canMakePayments is exposed as a constant.
       resolve(ReactNativePayments.canMakePayments);
     });
+  },
+
+  applePayEnabled() {
+    if (Platform.OS === 'ios') {
+      return ReactNativePayments.canMakePayments;
+    }
+    return false;
   },
 
   // TODO based on Naoufal's talk on YouTube the intention of canMakePayments is for it to work like this, so I'm thinking we can integrate Yegor's code into canMakePayments.

--- a/js/PaymentRequest/index.js
+++ b/js/PaymentRequest/index.js
@@ -534,6 +534,7 @@ export default class PaymentRequest {
     );
   }
 
+  static applePayEnabled = NativePayments.applePayEnabled;
   static canMakePaymentsUsingNetworks = NativePayments.canMakePaymentsUsingNetworks;
   static openPaymentSetup = NativePayments.openPaymentSetup;
 }


### PR DESCRIPTION
It's problematic for our use case to have to have to construct a payment request
in order to check if apple pay is enabled on the device via canMakePayments
instance method.

add a static method that lets us check if apple pay is enabled on the device.

<!-- ps-id: 36eab9f2-b5ed-4852-bcee-51262e81ab2f -->