### PR TITLE
Fix podspec so that it can validate.

### DIFF
--- a/react-native-payments.podspec
+++ b/react-native-payments.podspec
@@ -9,7 +9,7 @@ Pod::Spec.new do |s|
   s.license          = pkg["license"]
   s.homepage         = pkg["homepage"]
   s.author           = pkg["author"]
-  s.source           = { :git => pkg["repository"] }
+  s.source           = { :git => pkg["repository"]["url"], :tag => "#{s.version}" }
   s.source_files     = 'ios/**/*.{h,m}'
   s.platform         = :ios, "8.0"
   s.requires_arc     = true


### PR DESCRIPTION
This fixes the following error message received when we tried to install this in
an expo project running Expo SDK 50.
```
[!] The `react-native-payments` pod failed to validate due to 1 error:
    - ERROR | source: Unable to validate due to exception: undefined method `=~' for an instance of Hash
```

<!-- ps-id: d5f62f23-b57a-43f0-882f-bf013394f75a -->