### PR TITLE
Remove Android support libraries to fix building on Expo 52

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -27,5 +27,4 @@ dependencies {
     implementation 'com.google.android.gms:play-services-base:17.0.0'
     implementation 'com.google.android.gms:play-services-identity:17.0.0'
     implementation 'com.google.android.gms:play-services-wallet:17.0.0'
-    implementation 'com.android.support:support-v4:23.0.1'
 }


### PR DESCRIPTION
Resolves these errors:

```
* What went wrong: Execution failed for task ':app:checkDebugDuplicateClasses'.
> A failure occurred while executing com.android.build.gradle.internal.tasks.CheckDuplicatesRunnable
   > Duplicate class android.support.v4.app.INotificationSideChannel found in modules core-1.13.1.aar -> core-1.13.1-runtime (androidx.core:core:1.13.1) and support-v4-23.0.1.aar -> support-v4-23.0.1-runtime (com.android.support:support-v4:23.0.1)
     Duplicate class android.support.v4.app.INotificationSideChannel$Stub found in modules core-1.13.1.aar -> core-1.13.1-runtime (androidx.core:core:1.13.1) and support-v4-23.0.1.aar -> support-v4-23.0.1-runtime (com.android.support:support-v4:23.0.1)
     Duplicate class android.support.v4.app.INotificationSideChannel$Stub$Proxy found in modules core-1.13.1.aar -> core-1.13.1-runtime (androidx.core:core:1.13.1) and support-v4-23.0.1.aar -> support-v4-23.0.1-runtime (com.android.support:support-v4:23.0.1)
     Duplicate class android.support.v4.media.MediaDescriptionCompat found in modules media-1.0.0.aar -> media-1.0.0-runtime (androidx.media:media:1.0.0) and support-v4-23.0.1.aar -> support-v4-23.0.1-runtime (com.android.support:support-v4:23.0.1)
     Duplicate class android.support.v4.media.MediaDescriptionCompat$1 found in modules media-1.0.0.aar -> media-1.0.0-runtime (androidx.media:media:1.0.0) and support-v4-23.0.1.aar -> support-v4-23.0.1-runtime (com.android.support:support-v4:23.0.1)
     Duplicate class android.support.v4.media.MediaDescriptionCompat$Builder found in modules media-1.0.0.aar -> media-1.0.0-runtime (androidx.media:media:1.0.0) and support-v4-23.0.1.aar -> support-v4-23.0.1-runtime (com.android.support:support-v4:23.0.1)
     Duplicate class android.support.v4.media.MediaDescriptionCompatApi21 found in modules media-1.0.0.aar -> media-1.0.0-runtime (androidx.media:media:1.0.0) and support-v4-23.0.1.aar -> support-v4-23.0.1-runtime (com.android.support:support-v4:23.0.1)
     Duplicate class android.support.v4.media.MediaDescriptionCompatApi21$Builder found in modules media-1.0.0.aar -> media-1.0.0-runtime (androidx.media:media:1.0.0) and support-v4-23.0.1.aar -> support-v4-23.0.1-runtime (com.android.support:support-v4:23.0.1)
     Duplicate class android.support.v4.media.MediaDescriptionCompatApi23 found in modules media-1.0.0.aar -> media-1.0.0-runtime (androidx.media:media:1.0.0) and support-v4-23.0.1.aar -> support-v4-23.0.1-runtime (com.android.support:support-v4:23.0.1)
     Duplicate class android.support.v4.media.MediaDescriptionCompatApi23$Builder found in modules media-1.0.0.aar -> media-1.0.0-runtime (androidx.media:media:1.0.0) and support-v4-23.0.1.aar -> support-v4-23.0.1-runtime (com.android.support:support-v4:23.0.1)
```