### PR TITLE
Add CODEOWNERS and catalog-info.yaml

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Default owners for all files in this repo
+* @appfolio/resident-mobile

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,9 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: react-native-payments
+  description: "Accept Payments with Apple Pay and Android Pay using the Payment Request API."
+spec:
+  type: library
+  lifecycle: stable
+  owner: CODEOWNERS


### PR DESCRIPTION
Adds `.github/CODEOWNERS` and `catalog-info.yaml` to register this repo in the Developer Portal under `@appfolio/resident-mobile` ownership.

Part of the repo ownership initiative: https://docs.google.com/spreadsheets/d/1sd6gorLtYuBb3W4JWK1R_K-PnSTmbTJoH27SQG1_8gU