### PR TITLE
Add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Default owners for all files in this repo
+* @appfolio/resident-mobile


### PR DESCRIPTION
Adds `.github/CODEOWNERS` for security vulnerability routing under `@appfolio/resident-mobile` ownership.

npm packages are auto-cataloged in the Developer Portal — no `catalog-info.yaml` needed.

Part of the repo ownership initiative: https://docs.google.com/spreadsheets/d/1sd6gorLtYuBb3W4JWK1R_K-PnSTmbTJoH27SQG1_8gU